### PR TITLE
docs: add GSSoC'25 banner at the top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+![GSSoC'25](https://img.shields.io/badge/GirlScript%20Summer%20of%20Code-2025-orange?style=for-the-badge)
+
+
+---
+
 # **Flavor AI**
 > *Built with CodeBuff* 🚀
 


### PR DESCRIPTION
### Docs: add GSSoC'25 banner to README

Added the GSSoC'25 badge at the top of the README to highlight the project's participation in GSSoC 2025.  
Helps make the project more visible and welcoming to contributors.
