### PR TITLE
Add: Basic Pull Request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## 📄 Description
+
+Please describe your changes and what this PR addresses.
+
+## 🔗 Related Issue
+
+Closes #[ISSUE_NUMBER]
+
+## 📸 Screenshots (if applicable)
+
+(Add before/after screenshots if your change is visual)
+
+## ✅ Checklist
+
+- [ ] My code compiles without errors
+- [ ] I have tested my changes
+- [ ] I have updated documentation if necessary


### PR DESCRIPTION
This PR adds a basic Pull Request template to the `.github` folder to improve contribution consistency and collaboration.

Closes #36
