### PR TITLE
fix: remove random numbers from recipe instructions on all pages

### DIFF
--- a/components/AiRecipe.jsx
+++ b/components/AiRecipe.jsx
@@ -50,8 +50,18 @@ export default function AiRecipe({ recipe, setShowRecipe, recipeImageUrl }) {
             <PlusIcon2 />
             Instructions
           </h2>
-          <p className="text-base-content">{recipe.steps.join("\n")}</p>
-          <TextToSpeech text={recipe.steps.join(" ")} />
+          {recipe.steps && (
+            (() => {
+              // Remove leading numbers, dots, parentheses, and trim whitespace from each step
+              const cleanedSteps = recipe.steps
+                .map(step => step.replace(/^\s*\d+([.)])?\s*/, "").trim())
+                .filter(Boolean);
+              return <>
+                <p className="text-base-content">{cleanedSteps.join("\n")}</p>
+                <TextToSpeech sentences={cleanedSteps} onHighlightChange={() => {}} />
+              </>;
+            })()
+          )}
         </div>
       </div>
     </div>

--- a/components/ShowMeal.jsx
+++ b/components/ShowMeal.jsx
@@ -47,7 +47,11 @@ function ShowMeal({ URL }) {
 
   const instructionSentences = useMemo(() => {
     if (!mealData?.strInstructions) return [];
-    return mealData.strInstructions.split(/\r?\n/).filter(s => s.trim());
+    // Clean each instruction: remove leading numbers, dots, parentheses, and trim whitespace
+    return mealData.strInstructions
+      .split(/\r?\n/)
+      .map(s => s.replace(/^\s*\d+([.)])?\s*/, "").trim())
+      .filter(Boolean);
   }, [mealData]);
 
   useEffect(() => {


### PR DESCRIPTION
## 📄 Description

While viewing detailed recipe instructions (e.g., Baingan Bharta), unnecessary numeric values like 11, 12, 13, etc., were appearing between valid instruction steps. These numbers did not correspond to any step and disrupted the readability of the instructions.

Outcome
Users will now see clean, clearly numbered recipe instructions without confusing or irrelevant numbers.

## 🔗 Related Issue

Closes #22

## 📸 Screenshots (if applicable)
before:
<img width="892" height="521" alt="image" src="https://github.com/user-attachments/assets/2a98c982-131b-4b2f-b0fa-b509eb7e062d" />
after:
<img width="861" height="910" alt="image" src="https://github.com/user-attachments/assets/93edfcc5-f722-4884-bd6c-f759cc5a8ab4" />
<img width="816" height="895" alt="image" src="https://github.com/user-attachments/assets/ea3d24e8-f823-475b-83d5-36f5aa74fe93" />

## ✅ Checklist

- ✅ My code compiles without errors
- ✅I have tested my changes
-✅ I have updated documentation if necessary
