### PR TITLE
Add All Contributors' Profile Pictures to End of README #98

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,5 +129,41 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
   </a>
 </p>
 ---
+## 👥 Contributors
+Thanks to these amazing people:
+
+<table>
+  <tr>
+    <td align="center"><a href="https://github.com/Ayushjhawar8"><img src="https://avatars.githubusercontent.com/u/102190798?v=4" width="80px;" alt="Ayush Jhawar"/><br /><sub><b>Ayush Jhawar</b></sub></a></td>
+    <td align="center"><a href="https://github.com/sanjanahegde06"><img src="https://avatars.githubusercontent.com/u/115525364?v=4" width="80px;" alt="Sanjana Shrikant Hegde"/><br /><sub><b>Sanjana Hegde</b></sub></a></td>
+    <td align="center"><a href="https://github.com/Ramizalam"><img src="https://avatars.githubusercontent.com/u/114028505?v=4" width="80px;" alt="Ramiz Alam"/><br /><sub><b>Ramiz Alam</b></sub></a></td>
+    <td align="center"><a href="https://github.com/RAGHU1242"><img src="https://avatars.githubusercontent.com/u/122885857?v=4" width="80px;" alt="MUKKU RAGHAVENDRA"/><br /><sub><b>RAGHAVENDRA</b></sub></a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/ayanfarooque"><img src="https://avatars.githubusercontent.com/u/124408557?v=4" width="80px;" alt="Ayan Ahmad Farooque"/><br /><sub><b>Ayan Ahmad</b></sub></a></td>
+    <td align="center"><a href="https://github.com/GxAditya"><img src="https://avatars.githubusercontent.com/u/91730797?v=4" width="80px;" alt="Aditya Kumar"/><br /><sub><b>Aditya Kumar</b></sub></a></td>
+    <td align="center"><a href="https://github.com/MatheusFC2"><img src="https://avatars.githubusercontent.com/u/104938216?v=4" width="80px;" alt="Matheus Freitas Campos"/><br /><sub><b>Matheus Campos</b></sub></a></td>
+    <td align="center"><a href="https://github.com/Vidhi-Mathur"><img src="https://avatars.githubusercontent.com/u/102884308?v=4" width="80px;" alt="Vidhi Mathur"/><br /><sub><b>Vidhi Mathur</b></sub></a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/Bhawneet1"><img src="https://avatars.githubusercontent.com/u/122182425?v=4" width="80px;" alt="Bhawneet Singh"/><br /><sub><b>Bhawneet Singh</b></sub></a></td>
+    <td align="center"><a href="https://github.com/anmolsah"><img src="https://avatars.githubusercontent.com/u/139746212?v=4" width="80px;" alt="Anmol Sah"/><br /><sub><b>Anmol Sah</b></sub></a></td>
+    <td align="center"><a href="https://github.com/Mohammedamaan5714"><img src="https://avatars.githubusercontent.com/u/133161660?v=4" width="80px;" alt="Mohammed Amaan Ahmad"/><br /><sub><b>Amaan Ahmad</b></sub></a></td>
+    <td align="center"><a href="https://github.com/amshula-05"><img src="https://avatars.githubusercontent.com/u/152438093?v=4" width="80px;" alt="amshula-05"/><br /><sub><b>amshula-05</b></sub></a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/HimanshuSolo2005"><img src="https://avatars.githubusercontent.com/u/133719153?v=4" width="80px;" alt="Himanshu"/><br /><sub><b>Himanshu</b></sub></a></td>
+    <td align="center"><a href="https://github.com/om07github"><img src="https://avatars.githubusercontent.com/u/103148994?v=4" width="80px;" alt="Om Mahalle"/><br /><sub><b>Om Mahalle</b></sub></a></td>
+    <td align="center"><a href="https://github.com/KadimiJaswanth"><img src="https://avatars.githubusercontent.com/u/132264049?v=4" width="80px;" alt="KadimiJaswanth"/><br /><sub><b>Jaswanth Kadimi</b></sub></a></td>
+    <td align="center"><a href="https://github.com/AasthathecoderX"><img src="https://avatars.githubusercontent.com/u/134165130?v=4" width="80px;" alt="AasthathecoderX"/><br /><sub><b>Aastha</b></sub></a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/RAJVEER42"><img src="https://avatars.githubusercontent.com/u/132558331?v=4" width="80px;" alt="Rajveer Bishnoi"/><br /><sub><b>Rajveer Bishnoi</b></sub></a></td>
+    <td align="center"><a href="https://github.com/Aripilli-Bhavana"><img src="https://avatars.githubusercontent.com/u/130555560?v=4" width="80px;" alt="Aripilli Bhavana"/><br /><sub><b>Bhavana Aripilli</b></sub></a></td>
+    <td align="center"><a href="https://github.com/sidhuk-ai"><img src="https://avatars.githubusercontent.com/u/137205202?v=4" width="80px;" alt="Siddharth Kovi"/><br /><sub><b>Siddharth Kovi</b></sub></a></td>
+    <td align="center"><a href="https://github.com/heyysiri"><img src="https://avatars.githubusercontent.com/u/136935353?v=4" width="80px;" alt="Siri"/><br /><sub><b>Siri</b></sub></a></td>
+  </tr>
+</table>
+--- 
 Built with CodeBuff 🚀
 


### PR DESCRIPTION
# **Add Contributors Section with Profile Pictures to README** #98 

## Description
This PR adds a dedicated "Contributors" section at the end of the `README.md` file for the [Flavor-ai](https://github.com/Ayushjhawar8/Flavor-ai) project.

* Displays GitHub profile pictures (PFPs) of all contributors
* Each image links to the contributor’s GitHub profile
* Includes alt text for accessibility
* Uses a responsive HTML <table> layout for neat formatting

## Tasks Completed
 * Collected GitHub usernames of all contributors
 * Generated profile image grid with proper links and alt text
 * Ensured visual formatting is clean and mobile-responsive
 * Extended thanks with GitHub mentions (see below)

## Extended Thanks To All Contributors
Huge thanks to the amazing contributors who made this project better! 👇
We appreciate your time, code, and collaboration ❤️

@Ayushjhawar8
@sanjanahegde06
@Ramizalam
@RAGHU1242
@ayanfarooque
@GxAditya
@MatheusFC2
@Vidhi-Mathur
@Bhawneet1
@anmolsah
@Mohammedamaan5714
@amshula-05
@HimanshuSolo2005
@om07github
@KadimiJaswanth
@AasthathecoderX
@RAJVEER42
@Aripilli-Bhavana
@sidhuk-ai
@heyysiri

---

@Ayushjhawar8 Please Check, Review and Merge
And feel free to reach out and let me know if you need further modification or changes accordingly.

Thank you !!!