### PR TITLE
Add automatic contributors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,13 +133,11 @@ Thanks to all the amazing people who have contributed to this project! 🎉
 
 <div align="center">
   <a href="https://github.com/Ayushjhawar8/Flavor-ai/graphs/contributors">
-    <img src="https://contrib.rocks/image?repo=Ayushjhawar8/Flavor-ai&max=100&columns=10" alt="Contributors" />
+    <img src="https://contrib.rocks/image?repo=Ayushjhawar8/Flavor-ai&max=100&columns=10" alt="Contributors to Flavor AI" />
   </a>
 </div>
 
-<div align="center">
-  <sub>Made with <a href="https://contrib.rocks">contrib.rocks</a></sub>
-</div>
+
 
 <p align="center">
   <a href="/" style="text-decoration:none;">

--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - [Live Demo](https://flavor-ai-dish.netlify.app/)
 - [GitHub Repository](https://github.com/Ayushjhawar8/flavor-ai)
 
+## 👥 Contributors
+
+<a href="https://github.com/Ayushjhawar8/Flavor-ai/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Ayushjhawar8/Flavor-ai" />
+</a>
+
 <p align="center">
   <a href="/" style="text-decoration:none;">
     <strong>🔝 Back to Top</strong>

--- a/README.md
+++ b/README.md
@@ -132,9 +132,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 Thanks to all the amazing people who have contributed to this project! 🎉
 
 <div align="center">
-  <a href="https://contrib.rocks/image?repo=Ayushjhawar8/Flavor-ai">
-    <img src="https://contrib.rocks/image?repo=Ayushjhawar8/Flavor-ai&max=100&columns=10" alt="Contributors to Flavor AI" />
-  </a>
+  <img src="https://contrib.rocks/image?repo=Ayushjhawar8/Flavor-ai&max=100&columns=10" alt="Contributors to Flavor AI" />
 </div>
 
 

--- a/README.md
+++ b/README.md
@@ -129,9 +129,17 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 👥 Contributors
 
-<a href="https://github.com/Ayushjhawar8/Flavor-ai/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=Ayushjhawar8/Flavor-ai" />
-</a>
+Thanks to all the amazing people who have contributed to this project! 🎉
+
+<div align="center">
+  <a href="https://github.com/Ayushjhawar8/Flavor-ai/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=Ayushjhawar8/Flavor-ai&max=100&columns=10" alt="Contributors" />
+  </a>
+</div>
+
+<div align="center">
+  <sub>Made with <a href="https://contrib.rocks">contrib.rocks</a></sub>
+</div>
 
 <p align="center">
   <a href="/" style="text-decoration:none;">

--- a/README.md
+++ b/README.md
@@ -131,8 +131,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 Thanks to all the amazing people who have contributed to this project! 🎉
 
-<a href="https://github.com/Ayushjhawar8"><img src="https://github.com/Ayushjhawar8.png" width="50" height="50" alt="Ayushjhawar8" style="border-radius: 50%;"></a>
-<a href="https://github.com/contributors-img/contributors-img"><img src="https://contributors-img.web.app/image?repo=Ayushjhawar8/Flavor-ai" alt="Contributors" /></a>
+<img src="https://contributors-img.web.app/image?repo=Ayushjhawar8/Flavor-ai" alt="Contributors" />
 
 
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 Thanks to all the amazing people who have contributed to this project! 🎉
 
 <div align="center">
-  <img src="https://contrib.rocks/image?repo=Ayushjhawar8/Flavor-ai&max=100&columns=10" alt="Contributors to Flavor AI" usemap="#contributors-map" />
+  <a href="https://contrib.rocks/image?repo=Ayushjhawar8/Flavor-ai">
+    <img src="https://contrib.rocks/image?repo=Ayushjhawar8/Flavor-ai&max=100&columns=10" alt="Contributors to Flavor AI" />
+  </a>
 </div>
 
 

--- a/README.md
+++ b/README.md
@@ -131,8 +131,18 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 Thanks to all the amazing people who have contributed to this project! 🎉
 
+
+
+
+
+
 <div align="center">
-  <img src="https://contrib.rocks/image?repo=Ayushjhawar8/Flavor-ai&max=100&columns=10" alt="Contributors to Flavor AI" usemap="#contributors-map" />
+
+
+  <a href="https://github.com/Ayushjhawar8/Flavor-ai/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=Ayushjhawar8/Flavor-ai&max=100&columns=10" alt="Contributors" />
+  </a>
+
 </div>
 
 

--- a/README.md
+++ b/README.md
@@ -132,9 +132,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 Thanks to all the amazing people who have contributed to this project! 🎉
 
 <div align="center">
-  <a href="https://github.com/Ayushjhawar8/Flavor-ai/graphs/contributors">
-    <img src="https://contrib.rocks/image?repo=Ayushjhawar8/Flavor-ai&max=100&columns=10" alt="Contributors to Flavor AI" />
-  </a>
+  <img src="https://contrib.rocks/image?repo=Ayushjhawar8/Flavor-ai&max=100&columns=10" alt="Contributors to Flavor AI" usemap="#contributors-map" />
 </div>
 
 

--- a/README.md
+++ b/README.md
@@ -131,9 +131,8 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 Thanks to all the amazing people who have contributed to this project! 🎉
 
-<div align="center">
-  <img src="https://contrib.rocks/image?repo=Ayushjhawar8/Flavor-ai&max=100&columns=10" alt="Contributors to Flavor AI" />
-</div>
+<a href="https://github.com/Ayushjhawar8"><img src="https://github.com/Ayushjhawar8.png" width="50" height="50" alt="Ayushjhawar8" style="border-radius: 50%;"></a>
+<a href="https://github.com/contributors-img/contributors-img"><img src="https://contributors-img.web.app/image?repo=Ayushjhawar8/Flavor-ai" alt="Contributors" /></a>
 
 
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 Thanks to all the amazing people who have contributed to this project! 🎉
 
-<img src="https://contributors-img.web.app/image?repo=Ayushjhawar8/Flavor-ai" alt="Contributors" />
+<div align="center">
+  <img src="https://contrib.rocks/image?repo=Ayushjhawar8/Flavor-ai&max=100&columns=10" alt="Contributors to Flavor AI" usemap="#contributors-map" />
+</div>
 
 
 
@@ -142,4 +144,3 @@ Thanks to all the amazing people who have contributed to this project! 🎉
 </p>
 ---
 Built with CodeBuff 🚀
-


### PR DESCRIPTION
## 📄 Description

Added an automatic contributors section to the README that displays all project contributors with their profile pictures. The section automatically updates when new contributors are added to the repository using the contrib.rocks service.

## 🔗 Related Issue

Closes #98

## 📸 Screenshots (if applicable)

**Before:**  No contributors section in README 
<img width="1290" height="558" alt="Screenshot 2025-08-01 003959" src="https://github.com/user-attachments/assets/71d8c5a7-0a7a-41ed-a0a0-718c91bb9788" />

**After:**  Contributors section with profile pictures automatically displayed at the bottom of README
<img width="1190" height="676" alt="Screenshot 2025-08-01 004021" src="https://github.com/user-attachments/assets/6aba0489-43ea-45fc-8f3b-5b416763699b" />

## ✅ Checklist

- [x] My code compiles without errors
- [x] I have tested my changes
- [x] I have updated documentation if necessary

**Changes made:**
- Added Contributors section to README.md
- Contributors automatically update when new people contribute
- Responsive layout with proper alt text for accessibility
