### PR TITLE
Added back-to-top button

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,11 +1,21 @@
 import { Inter } from "next/font/google";
+import ScrollToTop from "../components/ScrollToTop";
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"] });
 
 const patrickHand = {
   fontFamily: '"Patrick Hand", cursive',
-  fallback: ['-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'sans-serif']
+  fallback: [
+    "-apple-system",
+    "BlinkMacSystemFont",
+    "Segoe UI",
+    "Roboto",
+    "Oxygen",
+    "Ubuntu",
+    "Cantarell",
+    "sans-serif",
+  ],
 };
 
 export const metadata = {
@@ -20,13 +30,22 @@ export default function RootLayout({ children }) {
           rel="icon"
           href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🍱</text></svg>"
         />
-      
-      
+
         <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link href="https://fonts.googleapis.com/css2?family=Patrick+Hand&display=swap" rel="stylesheet" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Patrick+Hand&display=swap"
+          rel="stylesheet"
+        />
       </head>
-      <body className={inter.className} style={patrickHand}>{children}</body>
+      <body className={inter.className} style={patrickHand}>
+        {children}
+        <ScrollToTop></ScrollToTop>
+      </body>
     </html>
   );
 }

--- a/components/ScrollToTop.jsx
+++ b/components/ScrollToTop.jsx
@@ -1,0 +1,41 @@
+"use client";
+import { ArrowUpIcon } from "@heroicons/react/24/solid";
+import React, { useEffect, useState } from "react";
+
+const BackToTop = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      if (window.scrollY > 400) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+
+    window.addEventListener("scroll", toggleVisibility);
+    return () => window.removeEventListener("scroll", toggleVisibility);
+  }, []);
+
+  const handleBackToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  return (
+    <>
+      {isVisible && (
+        <div
+          className="fixed bottom-6 right-6 z-50 cursor-pointer"
+          onClick={handleBackToTop}
+        >
+          <div className="btn btn-primary btn-circle shadow-lg hover:scale-110 transition-transform duration-300">
+            <ArrowUpIcon className="w-5 h-5 text-primary-content" />
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default BackToTop;


### PR DESCRIPTION
## 📄 Description

This PR adds a "Back to Top" button that becomes visible when the user scrolls down the page beyond 400px. The button uses a Heroicons `ArrowUpIcon` styled with TailwindCSS and DaisyUI to match the project's Tiramisu theme.

On click, the button smoothly scrolls the user back to the top of the page. This improves user experience, especially on long-scroll pages.

## 🔗 Related Issue

Closes #136  

## 📸 Screenshots (if applicable)
Light Mode :
<img width="1419" height="810" alt="Screenshot 2025-08-07 at 9 28 25 PM" src="https://github.com/user-attachments/assets/d52c9289-a527-4ce9-9efb-bfc642bf0bf9" />
Dark Mode:
<img width="1427" height="814" alt="Screenshot 2025-08-07 at 9 28 38 PM" src="https://github.com/user-attachments/assets/bdcbb4ac-4616-40a0-9ade-de85b8359981" />


## ✅ Checklist

- [x] My code compiles without errors
- [x] I have tested my changes on different screen sizes
- [x] I have used DaisyUI and Tailwind classes matching the theme
- [ ] I have updated documentation if necessary
