### PR TITLE
ensure back button goes behind navbar when scrolling

### DIFF
--- a/components/BackButton.tsx
+++ b/components/BackButton.tsx
@@ -95,8 +95,6 @@ function BackButton({ fallbackUrl = "/" }) {
                 WebkitTouchCallout: 'none',
                 WebkitUserSelect: 'none',
                 touchAction: 'manipulation',
-                // Ensure button is above other content
-                zIndex: 50,
                 // Force hardware acceleration for better mobile performance
                 transform: 'translateZ(0)',
                 willChange: 'transform'

--- a/components/BackButton.tsx
+++ b/components/BackButton.tsx
@@ -96,7 +96,6 @@ function BackButton({ fallbackUrl = "/" }) {
                 WebkitUserSelect: 'none',
                 touchAction: 'manipulation',
                 // Force hardware acceleration for better mobile performance
-                //aa
                 transform: 'translateZ(0)',
                 willChange: 'transform'
             }}

--- a/components/BackButton.tsx
+++ b/components/BackButton.tsx
@@ -96,6 +96,7 @@ function BackButton({ fallbackUrl = "/" }) {
                 WebkitUserSelect: 'none',
                 touchAction: 'manipulation',
                 // Force hardware acceleration for better mobile performance
+                //aa
                 transform: 'translateZ(0)',
                 willChange: 'transform'
             }}


### PR DESCRIPTION
PR Description

Summary
This PR fixes the issue where the back button was overlapping the navbar.
Now, when scrolling up, the back button correctly goes behind the navbar instead of sitting on top of it.

Changes Made
Adjusted z-index for the back button component.
Ensured UI consistency while keeping all existing functionality intact.

Motivation
Improves overall user experience and navigation flow.
Prevents visual overlap and maintains a clean UI.

Testing
Verified on different screen sizes.
Back button works as expected for both navigation and fallback URL.

fix #195