### PR TITLE
fix Back Button Overlapping Navbar issue

### DIFF
--- a/components/BackButton.tsx
+++ b/components/BackButton.tsx
@@ -70,13 +70,14 @@ function BackButton({ fallbackUrl = "/" }) {
     };
 
     return (
+        // Positioning adjusted to prevent overlap with fixed Navbar.
         <button
             className={`
                 btn btn-circle 
                 bg-base-200 hover:bg-base-300 
                 active:bg-base-300
-                absolute top-5 md:top-10 left-3 md:left-10 
-                z-0
+                fixed top-[70px] left-4 md:top-[80px] md:left-10 
+                z-40
                 transition-all duration-150 ease-in-out
                 select-none
                 ${isPressed ? 'scale-90 bg-base-300 shadow-inner' : 'scale-100 shadow-lg'}


### PR DESCRIPTION
## 📄 Description

This PR addresses a UI/UX issue where the BackButton component was overlapping with the fixed Navbar at the top of the page.
- Adjusted the top positioning of the BackButton to place it below the navbar.
- Increased the z-index to ensure proper layering.
- Added a comment to clarify the styling change for future contributors.

## 🔗 Related Issue

Closes #195 

## 📸 Screenshots (if applicable)

(Add before/after screenshots if your change is visual)
Before
<img width="1025" height="472" alt="1" src="https://github.com/user-attachments/assets/d92506f0-23bb-4153-9e7b-2a98ae86f79f" />
After
<img width="1906" height="897" alt="2" src="https://github.com/user-attachments/assets/9419dec8-2dae-4822-ba73-9c99d1828307" />



## ✅ Checklist

- [x] My code compiles without errors
- [x] I have tested my changes
- [ ] I have updated documentation if necessary
