### PR TITLE
Translate widget shifted

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -29,7 +29,6 @@ body::-webkit-scrollbar {
   transition: background-color 50ms ease-in-out;
 }
 
-/* By Devika Harshey */
 /* This class hides the scrollbar of the element to which it is applied. */
 @layer utilities {
   .scrollbar-none::-webkit-scrollbar {
@@ -37,54 +36,62 @@ body::-webkit-scrollbar {
   }
 }
 
-/* Scroll and selection UI - multilingual Support */
+/* Smooth scroll */
 html {
   scroll-behavior: smooth;
 }
 
+/* Scrollbar styles */
 ::-webkit-scrollbar {
   width: 5px;
   height: 5px;
 }
 ::-webkit-scrollbar-track {
-  background-color: var(--background-color);
+  background-color: var(--scrollbar-track, #f0f0f0);
 }
 ::-webkit-scrollbar-thumb {
-  background-color: purple;
+  background-color: var(--scrollbar-thumb, purple);
   border-radius: 20px;
 }
+
+/* Selection color */
 *::selection {
-  color: rgb(255, 255, 255);
-  background-color:purple;
+  color: #fff;
+  background-color: var(--selection-bg, purple);
+}
+
+/* Theme variables */
+:root {
+  --scrollbar-track: #f0f0f0;   
+  --scrollbar-thumb: purple;    
+  --selection-bg: purple;        
+}
+[data-theme="dark"] {
+  --scrollbar-track: #1f2937;   
+  --scrollbar-thumb: #a855f7;    
+  --selection-bg: #a855f7;
 }
 
 /* Google Translate Styles */
 .google-translate-container {
-  position: fixed;
-  bottom: 20px;
-  left: 20px;
-  z-index: 10000;
+  position: relative;  
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1rem;
+  cursor: pointer;
+  z-index: 1000;
+}
+.goog-te-gadget {
+  display: inline-flex !important;
+  align-items: center;
+  margin: 0 !important;
+  padding: 0 !important;
+  color: transparent !important;
 }
 .goog-logo-link,
 .goog-te-banner-frame,
 .VIpgJd-ZVi9od-l4eHX-hSRGPd,
-.VIpgJd-ZVi9od-ORHb-OEVmcd {
-  display: none !important;
-}
-.goog-te-gadget {
-  color: transparent !important;
-}
-.goog-te-gadget .goog-te-combo {
-  background-color: purple !important;
-  color: white !important;
-  font-size: 15px;
-  border: 2px dotted #ffffff;
-  border-radius: 5px;
-  padding: 4px;
-}
-.goog-te-gadget .goog-te-combo option {
-  color: white;
-}
+.VIpgJd-ZVi9od-ORHb-OEVmcd,
 #goog-gt-tt,
 .goog-te-balloon-frame {
   display: none !important;
@@ -93,6 +100,27 @@ html {
   background: none !important;
   box-shadow: none !important;
 }
-.google-translate-container.hidden {
+#google_translate_element {
   display: none !important;
+}
+.goog-te-banner-frame,
+#goog-gt-tt,
+.goog-tooltip,
+.goog-te-balloon-frame {
+  display: none !important;
+}
+.goog-te-banner-frame.skiptranslate,
+.goog-te-banner-frame,
+#goog-gt-tt {
+  display: none !important;
+}
+body {
+  top: 0px !important;
+}
+.content[style] {
+  margin-top: 0 !important;
+}
+.goog-te-combo:focus {
+  outline: none;
+  border: 2px solid #9333ea;
 }

--- a/components/GoogleTranslate.js
+++ b/components/GoogleTranslate.js
@@ -1,9 +1,33 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
+import { Globe } from "lucide-react";
 
 const GoogleTranslate = () => {
-  const [isVisible, setIsVisible] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const wrapperRef = useRef(null);
+  const [currentTheme, setCurrentTheme] = useState('dark');
+
+  useEffect(() => {
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'data-theme') {
+          const newTheme = document.documentElement.getAttribute('data-theme') || 'dark';
+          setCurrentTheme(newTheme);
+        }
+      });
+    });
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme']
+    });
+
+    const initialTheme = document.documentElement.getAttribute('data-theme') || 'dark';
+    setCurrentTheme(initialTheme);
+
+    return () => observer.disconnect();
+  }, []);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -11,14 +35,18 @@ const GoogleTranslate = () => {
     window.googleTranslateInit = () => {
       if (!window.google?.translate?.TranslateElement) {
         setTimeout(window.googleTranslateInit, 100);
-      } else {
-        new window.google.translate.TranslateElement({
-          pageLanguage: 'en',
-          includedLanguages: 'en,hi,mr,sa,ta,te,kn,ml,gu,pa,bn,ur,or,as,ne,sd,si,fr,de,es,zh,ja,ru',
-          layout: window.google.translate.TranslateElement.InlineLayout.HORIZONTAL,
-          autoDisplay: false,
-        }, 'google_element');
-        setIsVisible(true);
+      } 
+      else{
+        new window.google.translate.TranslateElement(
+          {
+            pageLanguage: 'en',
+            includedLanguages:
+              'en,hi,mr,sa,ta,te,kn,ml,gu,pa,bn,ur,or,as,ne,sd,si,fr,de,es,zh,ja,ru',
+            layout: window.google.translate.TranslateElement.InlineLayout.HORIZONTAL,
+            autoDisplay: false,
+          },
+          'google_element'
+        );
       }
     };
 
@@ -27,15 +55,111 @@ const GoogleTranslate = () => {
       script.id = 'google_translate_script';
       script.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateInit';
       script.async = true;
-      script.onerror = () => console.error('Google Translate failed to load');
       document.body.appendChild(script);
     } else {
       window.googleTranslateInit();
     }
   }, []);
 
+  const translateLanguage = (lang) => {
+    const selectEl = document.querySelector('#google_element select');
+    if (!selectEl) return;
+    selectEl.value = lang;
+    selectEl.dispatchEvent(new Event('change'));
+    setIsOpen(false);
+  };
+
+  const languages = [
+    { code: 'en', label: 'English' },
+    { code: 'hi', label: 'हिन्दी' },
+    { code: 'mr', label: 'मराठी' },
+    { code: 'sa', label: 'संस्कृतम्' },
+    { code: 'ta', label: 'தமிழ்' },
+    { code: 'te', label: 'తెలుగు' },
+    { code: 'kn', label: 'ಕನ್ನಡ' },
+    { code: 'ml', label: 'മലയാളം' },
+    { code: 'gu', label: 'ગુજરાતી' },
+    { code: 'pa', label: 'ਪੰਜਾਬੀ' },
+    { code: 'bn', label: 'বাংলা' },
+    { code: 'ur', label: 'اردو' },
+    { code: 'or', label: 'ଓଡ଼ିଆ' },
+    { code: 'as', label: 'অসমীয়া' },
+    { code: 'ne', label: 'नेपाली' },
+    { code: 'sd', label: 'سنڌي' },
+    { code: 'si', label: 'සිංහල' },
+    { code: 'fr', label: 'Français' },
+    { code: 'de', label: 'Deutsch' },
+    { code: 'es', label: 'Español' },
+    { code: 'zh', label: '中文' },
+    { code: 'ja', label: '日本語' },
+    { code: 'ru', label: 'Русский' },
+  ];
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const getDropdownBgColor = () => (currentTheme === 'dark' ? 'rgb(55,65,81)' : '#FFF8E7');
+  const getDropdownBorderColor = () => (currentTheme === 'dark' ? 'rgb(75,85,99)' : 'rgb(209,213,219)');
+  const getItemHoverBgColor = () => (currentTheme === 'dark' ? 'rgb(75,85,99)' : 'rgb(243,199,243)');
+  const getItemTextColor = () => (currentTheme === 'dark' ? '#FFFFFF' : '#1a1a1a');
+
   return (
-    <div id="google_element" className={`google-translate-container ${isVisible ? '' : 'hidden'}`} />
+    <div ref={wrapperRef} className="relative">
+      {/* Globe + Arrow button */}
+      <button
+        onClick={() => setIsOpen(prev => !prev)}
+        className="flex items-center gap-1 px-3 py-2 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+      >
+        <Globe className="w-5 h-5" />
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </button>
+
+      {/* Dropdown */}
+      {isOpen && (
+        <div
+          className="absolute right-0 mt-2 shadow-lg rounded-md z-50 min-w-[150px] max-h-64 overflow-y-auto"
+          style={{ backgroundColor: getDropdownBgColor(), border: `1px solid ${getDropdownBorderColor()}` }}
+        >
+          <ul className="flex flex-col text-sm">
+            {languages.map((lang) => (
+              <li key={lang.code}>
+                <button
+                  onClick={() => translateLanguage(lang.code)}
+                  style={{ color: getItemTextColor() }}
+                  className="w-full text-left px-4 py-2 transition-colors"
+                  onMouseEnter={(e) => e.currentTarget.style.backgroundColor = getItemHoverBgColor()}
+                  onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'transparent'}
+                >
+                  {lang.label}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Hidden Google element */}
+      <div id="google_element" style={{ display: 'none' }} />
+    </div>
   );
 };
 

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import ThemeToggle from "@/components/ThemeToggle";
 import RecipeSearchBar from "@/components/RecipeSearchBar";
+import GoogleTranslateWrapper from "@/components/GoogleTranslateWrapper";
 
 interface NavbarProps {
   showResults: boolean;
@@ -123,7 +124,8 @@ export default function Navbar({
       </div>
 
       {/* Right - Theme Toggle */}
-      <div className="ml-auto md:ml-0">
+      <div className="ml-auto md:ml-0 space-x-2">
+        <GoogleTranslateWrapper />
         <ThemeToggle />
       </div>
 

--- a/components/RecipeSearchBar.jsx
+++ b/components/RecipeSearchBar.jsx
@@ -7,7 +7,7 @@ import { SearchIcon, X } from "@/components/Icons";
 const RecipeSearchBar = ({
   isScrolled,
   handleSearchFocus,
-  handleBlur,
+  handleBlur = () => {}, // default to empty function
   showResults,
   setShowResults,
   className,
@@ -137,7 +137,7 @@ const RecipeSearchBar = ({
   const handleClickOutside = (e) => {
     if (!e.target.closest('#searchBar')) {
       setIsSearchOpen(false);
-      handleBlur();
+      if (typeof handleBlur === 'function') handleBlur();
     }
   };
 


### PR DESCRIPTION
## 📄 Description

This PR improves the accessibility and UX of the Google Translate widget by moving it from the bottom corner to the navbar and replacing the default select box with a custom globe-style dropdown.

### Changes include
- **Widget relocation:**  
  - Moved the Google Translate widget from the fixed bottom-right position to the navbar for easier access.

- **Custom globe dropdown:**  
  - Replaced the default Google Translate select with a **globe icon button**.  
  - Clicking the globe opens a dropdown with all supported languages.

- **Theme-aware styling:**  
  - Dropdown background, hover, and text colors dynamically follow the current theme (`light` or `dark`).  
  - Light theme uses **#F5DEB3** as the dropdown background and custom hover color.  
  - Dark theme uses Tailwind’s dark palette.

- **Dropdown behavior:**  
  - Closes when clicking outside the dropdown.  
  - Selecting a language triggers Google Translate programmatically.

- **Accessibility & UX:**  
  - Hover effects and transitions added.  
  - Mobile-friendly and responsive design.

## 🔗 Related Issue

Closes #194 

## 📸 Screenshots 
before
<img width="1919" height="879" alt="Screenshot 2025-08-16 170126" src="https://github.com/user-attachments/assets/76ceebd5-024b-422e-9276-40264f0a1a86" />

after
<img width="1915" height="891" alt="image" src="https://github.com/user-attachments/assets/bf43aa72-e457-4930-8e44-c4de403d1373" />


(Add before/after screenshots if your change is visual)

## ✅ Checklist

- [x] My code compiles without errors
- [x] I have tested my changes
- [x] I have updated documentation if necessary
