### PR TITLE
Back button for diet planner

### DIFF
--- a/app/diet-planner/page.jsx
+++ b/app/diet-planner/page.jsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import Footer from "@/components/Footer";
 import Navbar from "@/components/Navbar";
-import BackButton from "@/components/BackButton"; // Import the BackButton component
+import BackButton from "@/components/BackButton"; 
 
 export default function DietPlannerPage() {
   const [formData, setFormData] = useState({

--- a/app/diet-planner/page.jsx
+++ b/app/diet-planner/page.jsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import Footer from "@/components/Footer";
 import Navbar from "@/components/Navbar";
+import BackButton from "@/components/BackButton"; // Import the BackButton component
 
 export default function DietPlannerPage() {
   const [formData, setFormData] = useState({
@@ -85,7 +86,10 @@ export default function DietPlannerPage() {
   };
 
   return (
-    <div className="min-h-screen bg-base-100">
+    <div className="min-h-screen bg-base-100 relative">
+      {/* Back Button */}
+      <BackButton fallbackUrl="/" />
+      
       {/* Navigation */}
       <Navbar
         showResults={showResults}
@@ -95,7 +99,7 @@ export default function DietPlannerPage() {
       />
 
       <div className="container mx-auto md:mt-16 mt-28 px-4 py-8">
-        <div className="text-center mb-8">
+        <div className="text-center mb-8 mt-12 md:mt-0">
           <h1 className="text-4xl font-bold text-primary mb-4">
             🥗 AI Diet Planner
           </h1>


### PR DESCRIPTION
## 📄 Description

Added a Back button to the “🥗 AI Diet Planner” page.
All other pages already had a back button for easy navigation, but this page was missing one.
This update ensures consistency across pages and improves the user experience by allowing users to easily return to the previous screen.

## 🔗 Related Issue IMP*

Closes #217 

## 📸 Screenshots (if applicable)

Before:
<img width="1914" height="891" alt="Screenshot 2025-08-26 191721" src="https://github.com/user-attachments/assets/afce2e9f-897e-4476-8751-83640c995624" />
<img width="1918" height="889" alt="Screenshot 2025-08-26 192011" src="https://github.com/user-attachments/assets/ef14445b-584b-4ec3-98e6-be62daada619" />

After:
<img width="1888" height="887" alt="Screenshot 2025-08-26 192232" src="https://github.com/user-attachments/assets/ca8e1bfb-d0b6-4e7d-8b3a-5aa04dec44c7" />
<img width="1881" height="884" alt="Screenshot 2025-08-26 192216" src="https://github.com/user-attachments/assets/56f75633-bd59-4af6-ae18-97b4859242bd" />


## ✅ Checklist

- [x] My code compiles without errors
- [x] I have tested my changes
- [x] I have updated documentation if necessary
