### PR TITLE
Fix dark mode text

### DIFF
--- a/app/favorite/page.tsx
+++ b/app/favorite/page.tsx
@@ -26,6 +26,7 @@ export default function FavoritesPage() {
   const [showResults, setShowResults] = useState(false);
   const [favorites, setFavorites] = useState<Meal[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
+  const [currentTheme, setCurrentTheme] = useState("light");
 
   const handleSearchFocus = () => setShowResults(true);
 

--- a/app/favorite/page.tsx
+++ b/app/favorite/page.tsx
@@ -26,7 +26,6 @@ export default function FavoritesPage() {
   const [showResults, setShowResults] = useState(false);
   const [favorites, setFavorites] = useState<Meal[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
-  const [currentTheme, setCurrentTheme] = useState("light");
 
   const handleSearchFocus = () => setShowResults(true);
 

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -184,12 +184,12 @@ const [selectedDiets, setSelectedDiets] = useState([]);
               }`}>
               A Taste for Every Mood and Moment
             </h1>
-            <div className="flex flex-wrap gap-4 justify-center mb-8">
+            <div className="flex  flex-wrap gap-4 justify-center mb-8">
               {["All", "Vegetarian", "Non-Vegetarian"].map((type) => (
                 <button
                   key={type}
                   onClick={() => setFilter(type)}
-                  className={`btn btn-sm md:btn-md ${filter === type ? "btn-primary" : "btn-outline"} transition-all duration-200`}
+                  className={`btn btn-sm md:btn-md  ${filter === type ? "btn-primary" : "btn-outline"} transition-all duration-200`}
                 >
                   {type}
                 </button>
@@ -255,11 +255,12 @@ const [selectedDiets, setSelectedDiets] = useState([]);
                       />
                     </figure>
                     <div className="card-body">
-                      <h2 className="card-title text-lg md:text-xl text-gray-800 flex items-center gap-2">
+                      <h2 className="card-title text-lg md:text-xl text-base-content flex items-center">
                         <PlusIcon />
                         {category.strCategory}
                       </h2>
-                      <p className="text-sm text-gray-600">{category.strCategoryDescription.slice(0, 80)}...</p>
+                      <p className="text-sm md:text-base text-base-content">
+                        {category.strCategoryDescription.slice(0, 80)}...</p>
                       <div className="card-actions justify-end">
                         <Link href={`/category/${category.strCategory}`}>
                           <button className="btn btn-primary text-sm md:text-base">


### PR DESCRIPTION
## 📄 Description
This PR fixes the issue where the category dish descriptions were not visible in dark mode.

- Changed `text-gray-600` to `text-base-content` in the dish description text.
- `text-base-content` adapts automatically with DaisyUI themes, ensuring proper visibility in both light and dark modes.

The text is now clearly readable.

## 🔗 Related Issue IMP*

Closes #226

## 📸 Screenshots 
## before
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f0fa73aa-1946-4379-bd1c-04aff0edc182" />

## after
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7f38e0b0-9c43-452f-a944-cd051eea39b7" />

##  ✅ Checklist

- [✅ ] My code compiles without errors
- [ ✅] I have tested my changes
- [ ✅] I have updated documentation if necessary
