### PR TITLE
fix: resolve white corners in footer on dark mode

### DIFF
--- a/app/category/[category]/page.tsx
+++ b/app/category/[category]/page.tsx
@@ -160,7 +160,9 @@ export default function Page({ params }: PageProps) {
         </div>
       </div>
 
-      <Footer />
+      <div className="bg-base-100">
+        <Footer />
+      </div>
     </>
   );
 }

--- a/app/favorite/page.tsx
+++ b/app/favorite/page.tsx
@@ -148,7 +148,9 @@ export default function FavoritesPage() {
           </div>
         )}
       </div>
-      <Footer />
+      <div className="bg-base-100">
+        <Footer />
+      </div>
     </>
   );
 }

--- a/components/ShowMeal.jsx
+++ b/components/ShowMeal.jsx
@@ -547,7 +547,9 @@ function ShowMeal({ URL }) {
           </div>
         </div>
       </div>
-      <Footer />
+      <div className="bg-base-100">
+        <Footer />
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## 📄 Description

Fixed the issue where in **dark mode** the footer showed **white corners** due to the wrapper background being default. Updated the wrapper to use theme-aware background (`bg-base-100`), so it adapts correctly in both light and dark themes.

## 🔗 Related Issue IMP\*

Closes #231 

## 📸 Screenshots
**Before (dark mode):** white corners visible at footer edges
<img width="1440" height="188" alt="Screenshot 2025-08-28 at 12 55 21 PM" src="https://github.com/user-attachments/assets/00983a3c-54d6-4b17-9dcc-f0af3b3a440f" />

**After (dark mode):** footer blends seamlessly with background, no white corners
<img width="695" height="254" alt="Screenshot 2025-08-29 at 10 28 26 PM" src="https://github.com/user-attachments/assets/5bb299bf-65e7-48d6-be4c-03d18f90e7e2" />


## ✅ Checklist

* [x] My code compiles without errors
* [x] I have tested my changes
* [x] I have updated documentation if necessary
