### PR TITLE
Feat: Add Share Recipe button with Web Share + clipboard fallback (#249)

### DIFF
--- a/components/ShareButton.tsx
+++ b/components/ShareButton.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { ShareIcon } from "@heroicons/react/24/solid";
+
+type Props = {
+  title: string;          // recipe name
+  className?: string;
+  ariaLabel?: string;
+};
+
+export default function ShareButton({ title, className = "", ariaLabel }: Props) {
+  const [copied, setCopied] = useState(false);
+  const [shareSupported, setShareSupported] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && typeof navigator !== "undefined") {
+      setShareSupported(typeof (navigator as any).share === "function");
+    }
+  }, []);
+
+  const handleShare = useCallback(async () => {
+    if (typeof window === "undefined") return;
+    const url = window.location.href;
+
+    try {
+      if (shareSupported && (navigator as any).share) {
+        await (navigator as any).share({ title, url });
+        return;
+      }
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      try {
+        await navigator.clipboard.writeText(url);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      } catch {/* ignore */}
+    }
+  }, [shareSupported, title]);
+
+  return (
+    <div className={`relative inline-block ${className}`}>
+      <button
+        onClick={handleShare}
+        className="btn btn-outline btn-primary btn-sm gap-2"
+        aria-label={ariaLabel ?? "Share recipe"}
+      >
+        <ShareIcon className="h-5 w-5" />
+        Share
+      </button>
+
+      {copied && (
+        <span
+          role="status"
+          className="absolute -top-7 left-1/2 -translate-x-1/2 text-xs px-2 py-1 rounded bg-base-200 shadow border border-base-300"
+        >
+          Link copied!
+        </span>
+      )}
+    </div>
+  );
+}

--- a/components/ShowMeal.jsx
+++ b/components/ShowMeal.jsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { useEffect, useState, useMemo, useRef, useCallback } from "react";
 import Footer from "./Footer";
 import Navbar from "./Navbar";
+import ShareButton from "@/components/ShareButton";
 
 // --- Self-contained helper components ---
 function HighlightedSentence({ text, isActive, wordRange }) {
@@ -469,21 +470,26 @@ function ShowMeal({ URL }) {
                   alt={mealData.strMeal}
                   className="w-full h-auto rounded-lg shadow-md mb-4"
                 />
-                <div className="flex items-center gap-4">
-                  <span className="badge badge-lg badge-accent">
-                    {mealData.strCategory}
-                  </span>
-                  {mealData.strYoutube && (
-                    <Link
-                      href={mealData.strYoutube}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="btn btn-error btn-sm gap-2"
-                    >
-                      <YoutubeIcon /> Watch
-                    </Link>
-                  )}
-                </div>
+                <div className="flex flex-wrap items-center gap-4">
+  <span className="badge badge-lg badge-accent">
+    {mealData.strCategory}
+  </span>
+
+  {mealData.strYoutube && (
+    <Link
+      href={mealData.strYoutube}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="btn btn-error btn-sm gap-2"
+    >
+      <YoutubeIcon /> Watch
+    </Link>
+  )}
+
+  {/* NEW: Share button */}
+  <ShareButton title={mealData.strMeal} />
+</div>
+
               </div>
               <div className="md:w-1/2">
                 <h2 className="text-2xl font-bold mb-2 flex items-center justify-between text-base-content">


### PR DESCRIPTION
**## ✨ Summary**
This PR introduces a **Share Recipe** feature that makes it easy for users to share their favorite meals with friends across devices.  
The new button integrates with the **Web Share API** (for supported browsers) and gracefully falls back to **clipboard copy** with visual feedback.  

Closes #249  

---

**## 🔧 Changes Made**
- **New Component**: `ShareButton.tsx`
  - Client-side component that handles sharing logic.
  - Supports both native Web Share and fallback.
  - Provides temporary “Link copied!” toast when copying to clipboard.
  - Accessible via keyboard with `aria-label="Share recipe"`.
  
- **Meal Page Update (`ShowMeal`)**
  - Imported and integrated `ShareButton` in the recipe action row (beside YouTube button + category badge).
  - Ensures consistent styling (`btn btn-outline btn-primary`).
  - Adjusted container to `flex flex-wrap` so buttons don’t squash on smaller screens.

- **UI/UX Enhancements**
  - On supported browsers: opens **native share dialog** with recipe title + URL (as shown in screenshot).
  - On unsupported browsers: copies the recipe link to clipboard and shows `"Link copied!"` for ~1.5s.
  - Works seamlessly on **mobile and desktop**.
  - No intrusive popups; smooth inline feedback.

---

## 📸 Screenshots / Demo
<img width="1280" height="585" alt="image" src="https://github.com/user-attachments/assets/f3d33934-3f45-4034-a4fe-2d321ca793f4" />
<img width="443" height="389" alt="{D8ABF62E-AB70-4A0F-AE9D-E233411050C6}" src="https://github.com/user-attachments/assets/63702cbe-2248-45aa-b7c3-af63f3f45363" />

### 🔗 Native Share Dialog (Web Share API)  
When browser supports native sharing (e.g., Chrome, Edge, mobile browsers):  
![Web Share Dialog](<attach your screenshot here>)

- Title and URL automatically filled.  
- Options include Nearby Share, WhatsApp, Discord, Outlook, Gmail, Facebook, Twitter, LinkedIn, etc.  
- Extra options like **QR code** and **Copy Link** are auto-included by the system’s share UI.  

### 🖥️ Clipboard Fallback (Non-supporting browsers)  
- Copies current recipe URL (`window.location.href`) to clipboard.  
- Shows **“Link copied!”** badge for ~1.5 seconds above the button.  

---

**## ✅ Testing Checklist**
- [x] Share button visible on every recipe page.  
- [x] Works with **Web Share API** on supported browsers.  
- [x] Graceful fallback on unsupported browsers.  
- [x] “Link copied!” feedback shows and disappears as expected.  
- [x] Fully keyboard accessible (`Tab`, `Enter`, `Space`).  
- [x] No console warnings/errors.  

---

**## 🙌 Why this is valuable**
Sharing is one of the most common user actions. By adding this feature:  
- Improves **engagement** (easy for users to share recipes with family/friends).  
- Works across **mobile + desktop**.  
- Provides a **native-like experience** while ensuring compatibility everywhere.  
- Keeps UI consistent, clean, and accessible.  

---
