### PR TITLE
feat(ingredients): compact Servings UI + reliable per-row Metric/US conversion & scaling

### DIFF
--- a/components/ServingSizeControl.tsx
+++ b/components/ServingSizeControl.tsx
@@ -1,0 +1,83 @@
+"use client";
+import { useId } from "react";
+
+/** Minimal ± control; no numeric presets to keep UI clean */
+export default function ServingSizeControl({
+  servings,
+  setServings,
+  baseServings,
+  onReset,            // optional
+  showReset = false,  // set true if you want a Reset button rendered
+  min = 0.5,
+  max = 12,
+  step = 1,
+}) {
+  const id = useId();
+  const round = (n, dp = 2) => Math.round(n * 10 ** dp) / 10 ** dp;
+  const clampSet = (v) =>
+    setServings(Math.min(max, Math.max(min, round(Number(v)))));
+
+  const dec = () => clampSet(Number(servings) - step);
+  const inc = () => clampSet(Number(servings) + step);
+
+  const glyph = (n) => {
+    const close = (a, b) => Math.abs(a - b) < 0.001;
+    if (close(n % 1, 0.5)) return `${Math.floor(n) ? Math.floor(n) + " " : ""}½`;
+    if (close(n % 1, 0.25)) return `${Math.floor(n) ? Math.floor(n) + " " : ""}¼`;
+    if (close(n % 1, 0.75)) return `${Math.floor(n) ? Math.floor(n) + " " : ""}¾`;
+    return Number.isInteger(n) ? String(n) : String(round(n, 1));
+  };
+
+  return (
+    <div
+      className="inline-flex items-center gap-3 rounded-full border border-base-300/70 bg-base-200/60 px-3 py-2"
+      role="group"
+      aria-label="Serving size"
+    >
+      <label htmlFor={id} className="hidden sm:inline text-sm text-base-content/70">
+        Servings
+      </label>
+
+      <div className="inline-flex items-center gap-2">
+        <button
+          type="button"
+          onClick={dec}
+          aria-label="Decrease servings"
+          className="w-8 h-8 grid place-items-center rounded-full border border-base-300 bg-base-100 hover:bg-base-200 focus:outline-none"
+        >
+          &minus;
+        </button>
+
+        <span
+          id={id}
+          aria-live="polite"
+          className="min-w-[2.25rem] text-center text-sm font-semibold text-base-content/80"
+          title={`Current servings ×${servings}`}
+        >
+          ×{glyph(Number(servings))}
+        </span>
+
+        <button
+          type="button"
+          onClick={inc}
+          aria-label="Increase servings"
+          className="w-8 h-8 grid place-items-center rounded-full border border-base-300 bg-base-100 hover:bg-base-200 focus:outline-none"
+        >
+          +
+        </button>
+      </div>
+
+      {showReset && typeof onReset === "function" && (
+        <button
+          type="button"
+          onClick={onReset}
+          className="h-8 px-3 rounded-full text-xs border border-base-300 hover:bg-base-200"
+          title={`Reset to ${baseServings}`}
+          aria-label="Reset servings to base"
+        >
+          Reset
+        </button>
+      )}
+    </div>
+  );
+}

--- a/hooks/useServings.ts
+++ b/hooks/useServings.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+function keyFor(recipeId: string) {
+  return `servings:${recipeId}`;
+}
+
+/**
+ * Persists servings per recipe in localStorage.
+ * factor = servings / baseServings
+ */
+export function useServings(recipeId: string, baseServings: number) {
+  const [servings, setServings] = useState<number>(baseServings);
+
+  // load persisted value once
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(keyFor(recipeId));
+      if (raw) {
+        const v = Number(raw);
+        if (Number.isFinite(v) && v > 0) setServings(v);
+      }
+    } catch {}
+  }, [recipeId]);
+
+  // persist on change
+  useEffect(() => {
+    try {
+      localStorage.setItem(keyFor(recipeId), String(servings));
+    } catch {}
+  }, [recipeId, servings]);
+
+  const factor = useMemo(() => servings / baseServings, [servings, baseServings]);
+
+  const reset = useCallback(() => setServings(baseServings), [baseServings]);
+  return { servings, setServings, factor, reset };
+}

--- a/lib/formatQuantity.ts
+++ b/lib/formatQuantity.ts
@@ -1,0 +1,72 @@
+// Tiny "neat" formatter: prefers friendly cooking fractions (¼, ⅓, ½, ⅔, ¾),
+// otherwise falls back to 1-decimal rounding.
+export type UnitStyle = "auto" | "fraction" | "decimal";
+
+/** Units that look nice as fractions (spoons/cups/oz). Extend as you wish. */
+const FRACTION_UNITS = new Set([
+  "tsp","teaspoon","teaspoons",
+  "tbsp","tablespoon","tablespoons",
+  "cup","cups",
+  "oz","ounce","ounces",
+]);
+
+const GLYPH: Record<string, string> = {
+  "1/4": "¼",
+  "1/3": "⅓",
+  "1/2": "½",
+  "2/3": "⅔",
+  "3/4": "¾",
+};
+
+const FRIENDLY_FRACTIONS: Array<[number, number]> = [
+  [1,4],
+  [1,3],
+  [1,2],
+  [2,3],
+  [3,4],
+];
+
+/** Returns {intPart, fracGlyph | null} or null if not a friendly fraction */
+function nearestFriendlyFraction(frac: number, tolerance = 0.06) {
+  let best: {num: number; den: number; diff: number} | null = null;
+  for (const [num, den] of FRIENDLY_FRACTIONS) {
+    const v = num / den;
+    const diff = Math.abs(frac - v);
+    if (!best || diff < best.diff) best = { num, den, diff };
+  }
+  if (best && best.diff <= tolerance) {
+    return `${GLYPH[`${best.num}/${best.den}`] ?? `${best.num}/${best.den}`}`;
+  }
+  return null;
+}
+
+export function formatQuantity(
+  qty: number,
+  style: UnitStyle = "auto",
+  unit?: string
+): string {
+  if (!Number.isFinite(qty)) return "";
+
+  const preferFractions =
+    style === "fraction" ||
+    (style === "auto" && (unit ? FRACTION_UNITS.has(unit.toLowerCase()) : false));
+
+  // Round very close to whole numbers (e.g., 0.99 → 1)
+  if (Math.abs(qty - Math.round(qty)) < 0.02) {
+    return String(Math.round(qty));
+  }
+
+  if (preferFractions) {
+    const whole = Math.floor(qty);
+    const frac = qty - whole;
+    const glyph = nearestFriendlyFraction(frac);
+    if (glyph) {
+      if (whole === 0) return glyph;        // e.g., ½
+      return `${whole} ${glyph}`;           // e.g., 1 ¼
+    }
+  }
+
+  // default: 1 decimal
+  const rounded = Math.round(qty * 10) / 10;
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+}


### PR DESCRIPTION
## 📄 Description

This PR:
- Replaces crowded serving presets with a compact **± only** control.
- Fixes unit conversion so **every ingredient row** respects **Metric/US** toggle **and** servings **factor**.
- Normalizes common unit aliases (`tbs`, `tbl`, `gr`, `mls`, `floz`, etc.) **before** parsing to keep conversions consistent.
- Keeps all existing features intact: TTS (steps & ingredients), Add to list, Copy list, Share, Print, Favorites, Allergens.

**Key changes**
- `components/ShowMeal.jsx`
  - Per-row flow: **normalize → parse → scale by factor → pretty format → formatMeasureForSystem**.
  - Graceful fallback for descriptor measures (e.g., `1 sliced` → scales qty, keeps wording).
  - Layout polish:  
    - Row 1: **Servings (left)** · **Metric/US (right)**  
    - Row 2: **Add to list / Copy (left)** · **TTS controls (right)**
  - Quantity column uses `tabular-nums`, left-aligned.
- `components/ServingSizeControl.tsx`
  - Minimal **±** control, a11y-friendly labels, ½ ¼ ¾ glyphs, optional Reset hook retained.
- `hooks/useServings.ts`
  - Per-meal persistence; exposes `servings`, `factor`, `reset`.
- `lib/formatQuantity.ts`
  - Pretty-number helpers for clean display.

**Why**
Some recipes used non-canonical unit strings, so only the first ingredient converted. Normalizing units first fixes the bug and makes conversion reliable on **all rows**.

**Testing notes**
- Toggle **Metric ↔ US** repeatedly → every row updates.
- Change **servings ±** → all quantities scale and remain converted.
- Descriptor measures stay readable (“1 sliced” ×2 → “2 sliced”).
- TTS, Add to list, Copy list, Share, Print, Favorites — no regressions.
- Mobile/desktop layouts remain clean; sticky ingredients panel works.

---

## 🔗 Related Issue IMP*
Closes #260

---

## 📸 Screenshots 
Before:
<img width="876" height="756" alt="image" src="https://github.com/user-attachments/assets/b0846675-a171-403b-a511-c900f77762f6" />
After:
<img width="897" height="724" alt="image" src="https://github.com/user-attachments/assets/276c869e-534a-4ec9-bf86-81a8d2c58cea" />
<img width="887" height="770" alt="image" src="https://github.com/user-attachments/assets/645afdf1-2a15-4ec8-ac6b-c5e062a56431" />

---

## ✅ Checklist
- [ ] Code compiles without errors
- [ ] Manually tested across multiple recipes (Metric/US + servings ±)
- [ ] No regressions in TTS / shopping list / copy / share / print / favorites
- [ ] Updated screenshots in PR if UI changed
