### PR TITLE
Persist cursor toggle state using localStorage.

### DIFF
--- a/components/CursorToggle.jsx
+++ b/components/CursorToggle.jsx
@@ -1,10 +1,22 @@
+"use client";
 import React from "react";
 import { MousePointerClick } from "lucide-react";
 
 const CursorToggle = ({ cursorEnabled, setCursorEnabled }) => {
+  const handleClick = () => {
+    const next = !cursorEnabled;
+    // Persist to localStorage
+    try {
+      localStorage.setItem("cursorEnabled", JSON.stringify(next));
+    } catch (e) {
+      console.error("Failed to save cursorEnabled to localStorage", e);
+    }
+    setCursorEnabled(next);
+  };
+
   return (
     <button
-      onClick={() => setCursorEnabled(!cursorEnabled)}
+      onClick={handleClick}
       className="relative p-3 rounded-full bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 transition-all duration-200 border border-gray-200 dark:border-gray-700 shadow-sm hover:shadow-md ml-3"
       aria-label="Toggle animated cursor"
       title={cursorEnabled ? "Disable animated cursor" : "Enable animated cursor"}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -114,7 +114,32 @@ export default function Navbar({
 }: NavbarProps) {
   const [isScrolled, setIsScrolled] = useState(false);
   const [currentTheme, setCurrentTheme] = useState("light");
-  const [cursorEnabled, setCursorEnabled] = useState(true);
+
+  // Initialize cursorEnabled changes from localStorage
+  const [cursorEnabled, setCursorEnabled] = useState<boolean>(() => {
+    if (typeof window === "undefined") {
+      return true;
+    }
+    try {
+      const stored = localStorage.getItem("cursorEnabled");
+      if (stored !== null) {
+        return JSON.parse(stored);
+      }
+    } catch (e) {
+      console.error("Error reading cursorEnabled from localStorage", e);
+    }
+    return true; // default if not in storage
+  });
+
+  //Changes made on cursorEnabled, set localStorage ursorEnabled(true or false)
+  useEffect(() => {
+    try {
+      localStorage.setItem("cursorEnabled", JSON.stringify(cursorEnabled));
+    } catch (e) {
+      console.error("Error writing cursorEnabled to localStorage", e);
+    }
+  }, [cursorEnabled]);
+
 
   useEffect(() => {
     const handleScroll = () => {
@@ -150,12 +175,14 @@ export default function Navbar({
     return () => observer.disconnect();
   }, []);
 
+  //apply the cursor style to body
   useEffect(() => {
     document.body.style.cursor = cursorEnabled ? "none" : "default";
     return () => {
       document.body.style.cursor = "default";
     };
   }, [cursorEnabled]);
+
 
   return (
     <div


### PR DESCRIPTION
## Description

- This PR introduces changes so that the cursor mode toggle (animated cursor ↔ default arrow) is persisted using `localStorage`.
- Previously, the toggle would reset when navigating between pages (because the state was reinitialized).
- Now, the state is read from `localStorage` on mount, and updated in `localStorage` when toggled, so the cursor mode “sticks” across page loads.

---

## Related Issue / Bug (if any)
- Fixes:#303
---

## Steps to Reproduce 

1. Go to the site with the animated cursor enabled by default.  
2. Click the **CursorToggle** button to switch to arrow cursor.  
3. Navigate to another page (via client-side navigation).  
4. Observe that the cursor remains arrow (not switching back to animated).  
5. Reload the browser page / open in a new tab — confirm the arrow cursor persists.  
6. Toggle back to animated, navigate and reload again to confirm the change persists.

---

## What Was Changed

- **CursorToggle.jsx**: changed the onClick handler to first compute the new state (`next = !cursorEnabled`) and also write it to `localStorage` before calling `setCursorEnabled`.  
- **Navbar.tsx**: updated how `cursorEnabled` is initialized — using a function that reads the stored value from `localStorage`. Added a `useEffect` to sync changes to `localStorage` (safe-write).  
- **No changes** required in `SnakeCursor` component.
---

## Checklist
- [x] My code follows the project’s style
- [x] I tested the change manually (steps above)  
- [x] No new console errors or warnings  
---

https://github.com/user-attachments/assets/9401f24f-2b69-4057-9aad-4dc300340fbb

