### PR TITLE
Add: Move Nutrition AI section to dedicated page

### DIFF
--- a/app/ai/page.jsx
+++ b/app/ai/page.jsx
@@ -13,10 +13,6 @@ function Page() {
   const [showRecipe, setShowRecipe] = useState(false);
   const [showResults, setShowResults] = useState(false);
 
-  const [nutrition, setNutrition] = useState(null);
-const [nutritionInput, setNutritionInput] = useState("");
-const [loadingNutrition, setLoadingNutrition] = useState(false);
-const [showNutrition, setShowNutrition] = useState(false);
 
 
   const formResetRef = useRef();
@@ -34,27 +30,6 @@ const [showNutrition, setShowNutrition] = useState(false);
     }
   };
   
-  const fetchNutrition = async () => {
-  if (!nutritionInput.trim()) return;
-  setLoadingNutrition(true);
-  setNutrition(null);
-
-  try {
-    const res = await fetch("/api/analyze-nutrients", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ recipe: nutritionInput }),
-    });
-
-    const data = await res.json();
-    setNutrition(data.nutrition);
-  } catch (err) {
-    console.error("Nutrition API error:", err);
-    setNutrition({ error: "⚠️ Failed to fetch nutrition info." });
-  } finally {
-    setLoadingNutrition(false);
-  }
-};
 
   return (
    <>
@@ -108,76 +83,6 @@ const [showNutrition, setShowNutrition] = useState(false);
           </div>
         )}
 
-        {/* --- Nutrition AI Section --- */}
-{/* --- Nutrition AI Section --- */}
-<div className="w-full max-w-2xl mt-10 p-6 rounded-xl shadow-lg bg-base-200 border border-base-300">
-  <h2 className="text-2xl font-bold mb-4 text-brown-700">🍎 Nutrition AI</h2>
-
-  {!showNutrition ? (
-    // ✅ Open Nutrition AI Button
-    <button
-      className="btn btn-primary hover:bg-brown-700 text-white"
-      onClick={() => setShowNutrition(true)}
-    >
-      Open Nutrition AI
-    </button>
-  ) : (
-    <>
-      <textarea
-        className="w-full p-3 border border-base-300 rounded-lg mb-4 focus:outline-none focus:ring-2 focus:ring-brown-400"
-        placeholder="Paste your recipe ingredients here..."
-        value={nutritionInput}
-        onChange={(e) => setNutritionInput(e.target.value)}
-        rows={4}
-      />
-
-      <div className="flex space-x-3">
-        {/* ✅ Get Nutrition Info Button */}
-        <button
-          onClick={fetchNutrition}
-          disabled={loadingNutrition}
-          className="btn btn-primary hover:bg-brown-700 text-white disabled:opacity-50"
-        >
-          {loadingNutrition ? "Analyzing..." : "Get Nutrition Info"}
-        </button>
-
-        {/* ✅ Close Button */}
-        <button
-          className="btn btn-primary hover:bg-brown-700 text-white"
-          onClick={() => {
-            setShowNutrition(false);
-            setNutrition(null);
-            setNutritionInput("");
-          }}
-        >
-          Close
-        </button>
-      </div>
-
-      {nutrition && !nutrition.error && (
-        <div className="mt-6 p-4 rounded-lg bg-base-100 border border-base-300 shadow">
-          <h3 className="text-lg font-bold mb-2 text-brown-700">
-            Nutrition Facts (per serving)
-          </h3>
-          <table className="w-full border border-base-300 rounded-lg">
-            <tbody>
-              {Object.entries(nutrition).map(([key, value]) => (
-                <tr key={key} className="border-t border-base-300">
-                  <td className="p-2 font-semibold capitalize">{key}</td>
-                  <td className="p-2">{value}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-
-      {nutrition?.error && (
-        <p className="text-red-500 mt-4">{nutrition.error}</p>
-      )}
-    </>
-  )}
-</div>
 
 </div>
       <Footer />

--- a/app/nutrition-ai/page.jsx
+++ b/app/nutrition-ai/page.jsx
@@ -1,0 +1,137 @@
+"use client";
+
+import BackButton from "@/components/BackButton";
+import Footer from "@/components/Footer";
+import Navbar from "@/components/Navbar";
+import { useState } from "react";
+
+function NutritionAIPage() {
+  const [nutrition, setNutrition] = useState(null);
+  const [nutritionInput, setNutritionInput] = useState("");
+  const [loadingNutrition, setLoadingNutrition] = useState(false);
+  const [showResults, setShowResults] = useState(false);
+
+  const handleSearchFocus = () => setShowResults(true);
+  const handleBlur = () => setTimeout(() => setShowResults(false), 200);
+
+  const fetchNutrition = async () => {
+    if (!nutritionInput.trim()) return;
+    setLoadingNutrition(true);
+    setNutrition(null);
+
+    try {
+      const res = await fetch("/api/analyze-nutrients", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ recipe: nutritionInput }),
+      });
+
+      const data = await res.json();
+      setNutrition(data.nutrition);
+    } catch (err) {
+      console.error("Nutrition API error:", err);
+      setNutrition({ error: "⚠️ Failed to fetch nutrition info." });
+    } finally {
+      setLoadingNutrition(false);
+    }
+  };
+
+  const handleReset = () => {
+    setNutrition(null);
+    setNutritionInput("");
+  };
+
+  return (
+    <>
+      <Navbar
+        showResults={showResults}
+        setShowResults={setShowResults}
+        handleSearchFocus={handleSearchFocus}
+        handleBlur={handleBlur}
+      />
+      <div className={`min-h-screen py-10 bg-base-100 flex flex-col mt-20 justify-center items-center relative transition-all duration-300 ${
+        showResults ? "opacity-80 blur-sm" : "opacity-100"
+      }`}>
+        <div className="no-print">
+          <BackButton />
+        </div>
+
+        {/* Main Nutrition AI Section */}
+        <div className="w-full max-w-2xl p-6 rounded-xl shadow-lg bg-base-200 border border-base-300">
+          <div className="text-center mb-6">
+            <h1 className="text-3xl font-bold mb-2 text-brown-700">🧬 Nutrition AI</h1>
+            <p className="text-gray-600">Analyze the nutritional content of your recipes and ingredients</p>
+          </div>
+
+          <textarea
+            className="w-full p-3 border border-base-300 rounded-lg mb-4 focus:outline-none focus:ring-2 focus:ring-brown-400"
+            placeholder="Paste your recipe ingredients here..."
+            value={nutritionInput}
+            onChange={(e) => setNutritionInput(e.target.value)}
+            rows={6}
+          />
+
+          <div className="flex space-x-3 mb-4">
+            {/* Get Nutrition Info Button */}
+            <button
+              onClick={fetchNutrition}
+              disabled={loadingNutrition || !nutritionInput.trim()}
+              className="btn btn-primary hover:bg-brown-700 text-white disabled:opacity-50 flex-1"
+            >
+              {loadingNutrition ? "Analyzing..." : "Get Nutrition Info"}
+            </button>
+
+            {/* Clear Button */}
+            <button
+              className="btn btn-secondary"
+              onClick={handleReset}
+              disabled={!nutritionInput && !nutrition}
+            >
+              Clear
+            </button>
+          </div>
+
+          {nutrition && !nutrition.error && (
+            <div className="mt-6 p-4 rounded-lg bg-base-100 border border-base-300 shadow">
+              <h3 className="text-lg font-bold mb-4 text-brown-700">
+                Nutrition Facts (per serving)
+              </h3>
+              <div className="overflow-x-auto">
+                <table className="w-full border border-base-300 rounded-lg">
+                  <tbody>
+                    {Object.entries(nutrition).map(([key, value]) => (
+                      <tr key={key} className="border-t border-base-300 hover:bg-base-50">
+                        <td className="p-3 font-semibold capitalize text-brown-600">{key}</td>
+                        <td className="p-3">{value}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {nutrition?.error && (
+            <div className="mt-4 p-4 rounded-lg bg-red-50 border border-red-200">
+              <p className="text-red-600">{nutrition.error}</p>
+            </div>
+          )}
+
+          {/* Instructions */}
+          <div className="mt-6 p-4 rounded-lg bg-blue-50 border border-blue-200">
+            <h4 className="font-semibold text-blue-800 mb-2">How to use:</h4>
+            <ul className="text-sm text-blue-700 space-y-1">
+              <li>• Paste your recipe ingredients in the text area above</li>
+              <li>• Include quantities and measurements for accurate results</li>
+              <li>• Click "Get Nutrition Info" to analyze the nutritional content</li>
+              <li>• Results show nutrition facts per serving</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <Footer />
+    </>
+  );
+}
+
+export default NutritionAIPage;

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -66,6 +66,13 @@ const MobileNavigation = () => {
             <span className="text-gray-900 dark:text-gray-100">Festivals</span>
           </Link>
 
+          <Link href="/nutrition-ai" className="flex items-center gap-3 p-2 rounded-lg border">
+            <div className="bg-purple-800/70 rounded-full w-10 h-10 flex items-center justify-center">
+              <span className="text-white text-lg">🧬</span>
+            </div>
+            <span className="text-gray-900 dark:text-gray-100">Nutrition AI</span>
+          </Link>
+
           <Link href="/about" className="flex items-center gap-3 p-2 rounded-lg border">
             <div className="bg-purple-800/70 rounded-full w-10 h-10 flex items-center justify-center">
               <Info size={20} className="text-white" />
@@ -236,6 +243,17 @@ export default function Navbar({
             className="w-8 h-8 flex items-center justify-center rounded-full backdrop-blur-sm bg-white/10 dark:bg-black/20 border border-white/20 shadow-md transition-all duration-300 hover:scale-110 hover:shadow-lg"
           >
             <HelpCircle size={16} className={`${currentTheme === "dark" ? "text-white" : "dark:text-white text-black"}`} />
+          </Link>
+        </div>
+
+        {/* Nutrition AI */}
+        <div className="rounded-full p-1 dark:bg-purple-800 transition-colors duration-300 hidden md:block">
+          <Link
+            href="/nutrition-ai"
+            aria-label="Nutrition AI"
+            className="w-8 h-8 flex items-center justify-center rounded-full backdrop-blur-sm bg-white/10 dark:bg-black/20 border border-white/20 shadow-md transition-all duration-300 hover:scale-110 hover:shadow-lg"
+          >
+            <span className="text-sm">🧬</span>
           </Link>
         </div>
 


### PR DESCRIPTION

Moved the Nutrition AI section from the main AI recipe page to a dedicated standalone page.


Resolves issue #424 - improves navigation clarity and page organization by separating concerns.

##  What This PR Done
- Created new `/nutrition-ai` page with extracted functionality
- Removed Nutrition AI section from [/ai](cci:7://file:///Users/nitinsahu/Desktop/flavora%20ai/Flavor-ai/app/ai:0:0-0:0) page 
- Updated navigation (mobile & desktop) with 🧬 DNA emoji icon
- Enhanced UI with instructions and improved styling
- Maintained all existing API functionality (`/api/analyze-nutrients`)

##  Testing
- [x] New page loads correctly at `/nutrition-ai`
- [x] Navigation links work (mobile & desktop)
- [x] AI recipe page no longer contains nutrition section
- [x] All nutrition analysis functionality preserved

Closes #424

---
**Hacktoberfest 2025** contribution
Before:No section of Nutrition AI
<img width="1498" height="820" alt="Screenshot 2025-10-13 at 12 16 14 PM" src="https://github.com/user-attachments/assets/964c955c-88fc-497e-b679-48976948f464" />
After:Added a section of Nutrition AI in a New Page
<img width="1510" height="823" alt="Screenshot 2025-10-13 at 12 17 25 PM" src="https://github.com/user-attachments/assets/655ca835-43f4-4aba-b09b-cb3c5f51e814" />



