### PR TITLE
Fix: Back arrow overlapping with “Community Recipes” heading

### DIFF
--- a/app/community/page.jsx
+++ b/app/community/page.jsx
@@ -36,7 +36,12 @@ export default function CommunityPage() {
         handleSearchFocus={handleSearchFocus}
         handleBlur={handleBlur}
       />
-      <div className="absolute"><BackButton/></div>
+      <div style={{
+        position: 'absolute',
+        top: '-55px',
+        left: '-24px',
+        // position:'sticky'
+      }} className="absolute"><BackButton/></div>
 
       <div
         className={`min-h-screen mt-20 bg-base-100 transition-all duration-300 ${


### PR DESCRIPTION
## 📄 Description
This pull request fixes a UI alignment issue where the back arrow button overlapped with the “Community Recipes” heading.
The fix adjusts the layout and spacing to ensure proper alignment and readability.

## 🔗 Related Issue IMP*

Closes #413 

##Before:

Back arrow overlapped with the “Community Recipes” title

Heading appeared cluttered

##After:

Back arrow and heading are properly spaced

UI looks clean and aligned

## ✅ Checklist

- [ ✅] My code compiles without errors
- [✅ ] I have tested my changes
- [✅ ] I have updated documentation if necessary

<img width="1914" height="855" alt="Screenshot 2025-10-13 143817" src="https://github.com/user-attachments/assets/5e40e066-9584-4707-a12f-6b02a3d2f650" />
