### PR TITLE
Fixed comment interaction affecting all the recipe cards

### DIFF
--- a/app/community/page.jsx
+++ b/app/community/page.jsx
@@ -81,7 +81,7 @@ export default function CommunityPage() {
               </Link>
             </div>
           ) : (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 items-start">
               {recipes.map((recipe) => (
                 <CommunityRecipeCard key={recipe.id} recipe={recipe} />
               ))}


### PR DESCRIPTION
## 📄 Description

Fixed a layout issue in the Community Recipes page where opening the comment section on one recipe card caused all other cards in the same row to expand vertically.
This happened because the grid layout stretched all items to the same height.
The issue was resolved by adding items-start to the parent grid container so that each card’s height adjusts independently.



## 🔗 Related Issue IMP*

Closes #389 
Fixes #389 

## 📸 Screenshots (if applicable)

(Add before/after screenshots if your change is visual)

--before
<img width="1920" height="966" alt="image" src="https://github.com/user-attachments/assets/db3ebf26-280a-4a08-ba7b-3fa0d7ee5e37" />

--after

<img width="1842" height="945" alt="image" src="https://github.com/user-attachments/assets/b77e9be9-9cd4-4311-8aae-44e85130250a" />









## ✅ Checklist

- [✅  ] My code compiles without errors
- [ ✅ ] I have tested my changes
- [ ✅ ] I have updated documentation if necessary
