### PR TITLE
[Footer Inconsistency Fixed]Correct footer layout on home page for full width

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -118,12 +118,14 @@ export default function Page() {
         handleBlur={handleBlur}
       />
 
-      <div
-        className={`content flex flex-col items-center justify-center p-5 md:p-1 w-full bg-base-100 transition-all duration-300 relative z-10 ${
+      {/* Main container for all page content */}
+      <main className={`flex flex-col items-center justify-center w-full bg-base-100 transition-all duration-300 relative z-10 ${
           !showResults ? "opacity-100" : "opacity-80 blur-sm"
         }`}
       >
-      <section className="w-full h-screen bg-base-100 flex items-center justify-center relative z-10">{/* Floating background shapes */}
+
+     
+      <section className="w-full min-h-screen bg-base-100 flex items-center justify-center relative z-10">{/* Floating background shapes */}
  
         <div className={`absolute top-0 left-0 w-72 h-72 rounded-full filter blur-3xl animate-blob1 mix-blend-multiply ${
           currentTheme === "dark" ? "bg-purple-700/30" : "bg-purple-400/30"
@@ -318,8 +320,9 @@ export default function Page() {
           </section>
         )}
 
+      </main>
         <Footer />
-      </div>
+
     </>
   );
 }


### PR DESCRIPTION
## 📄 Description

This PR addresses a layout inconsistency where the footer on the home page appeared narrow and contained, while on other pages (like /community) it correctly spanned the full width of the viewport.

## 🔗 Related Issue IMP*

Closes #466 

## 📸 Screenshots (if applicable)

BEFORE (WITH BUG)
<img width="1354" height="730" alt="Screenshot 2025-10-16 230729" src="https://github.com/user-attachments/assets/9967d3e7-e60a-485a-9bd5-d3c7553cedcf" />
AFTER
<img width="1365" height="693" alt="image" src="https://github.com/user-attachments/assets/e93011ec-555b-4d3f-8e50-f871911e80b7" />


## ✅ Checklist

- [✅] My code compiles without errors
- [✅] I have tested my changes
- [✅] I have updated documentation if necessary

## Addtional
Project Admin: @Ayushjhawar8 
Please review this PR and Thank You So Much for this oppurtunity!

