### PR TITLE
Fix: darkmode in image upload

### DIFF
--- a/components/ImageUpload.jsx
+++ b/components/ImageUpload.jsx
@@ -118,13 +118,13 @@ function ImageUpload({ onIngredientsAnalyzed, analyzedIngredients = [] }) {
           />
           <label
             htmlFor="ingredient-image"
-            className="flex flex-col items-center justify-center w-full h-32 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer bg-gray-50 hover:bg-gray-100 transition-colors"
+            className="flex flex-col items-center bg-neutral/50 justify-center w-full h-32 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer bg-input-bg hover:bg-gray-100 transition-colors "
           >
             <PhotoIcon className="w-8 h-8 text-gray-400 mb-2" />
-            <span className="text-sm text-gray-500">
+            <span className="text-sm">
               Click to upload ingredient image
             </span>
-            <span className="text-xs text-gray-400">
+            <span className="text-xs ">
               PNG, JPG up to 5MB
             </span>
           </label>


### PR DESCRIPTION
## 📄 Description

Changed background color of image input from `bg-gray-50` to `bg-neutral/50`

## 🔗 Related Issue IMP*

Closes #487 


## 📸 Screenshots (if applicable)

<img width="300" height="601" alt="Screenshot From 2025-10-18 11-38-24" src="https://github.com/user-attachments/assets/b810d904-6aed-4796-af6b-d6120ec05f84" />

<img width="300" height="601" alt="Screenshot From 2025-10-18 11-45-05" src="https://github.com/user-attachments/assets/d3cdeca0-f509-4100-9c33-19c5bc47feaa" />

## ✅ Checklist

- [x] My code compiles without errors
- [x] I have tested my changes
- [ ] I have updated documentation if necessary
