### PR TITLE
Added top margin to Contact and FAQ page main containers to separate from navbar

### DIFF
--- a/app/FAQ/page.jsx
+++ b/app/FAQ/page.jsx
@@ -116,10 +116,10 @@ const FAQPage = () => {
   const [openIndex, setOpenIndex] = useState(null);
   const toggle = (i) => setOpenIndex(openIndex === i ? null : i);
   return (
-    <div className="flex flex-col min-h-screen bg-base-300">
+    <div className="flex flex-col min-h-screen bg-base-300 ">
       <Navbar />
       <div className="relative mt-10"><BackButton /></div>
-      <main className="flex-grow flex items-center justify-center p-4 sm:p-6 lg:p-8 pt-32">
+      <main className="flex-grow flex items-center justify-center p-4 mt-6 sm:p-6 lg:p-8 pt-32">
         <div className="w-full max-w-3xl bg-base-100 rounded-2xl shadow-xl p-8 space-y-6 transition-all duration-300">
           <div className="text-center">
             <h1 className="text-4xl font-bold text-primary">Frequently Asked Questions</h1>

--- a/app/contact/page.jsx
+++ b/app/contact/page.jsx
@@ -54,7 +54,7 @@ const ContactPage = () => {
       </div>
 
       {/* Main Content */}
-      <main className="flex-grow flex items-center justify-center p-4 sm:p-6 lg:p-8 pt-32">
+      <main className="flex-grow flex items-center justify-center p-4  mt-6 sm:p-6 lg:p-8 pt-32">
         <div className="w-full max-w-3xl bg-base-100 rounded-2xl shadow-xl p-6 sm:p-8 space-y-6 transition-all duration-300 ease-in-out">
           {/* Header Section */}
           <div className="text-center">


### PR DESCRIPTION
fixes #494 

## Description

Added top margin to main containers of Contact and FAQ pages.

Prevents content from sticking to the navbar.

Improves overall page layout and visual consistency.

<img width="1870" height="908" alt="image" src="https://github.com/user-attachments/assets/a43ee01c-c2c3-448e-af6d-146dd66a5b6c" />
<img width="1900" height="918" alt="image" src="https://github.com/user-attachments/assets/dde64f94-be93-470d-b4d4-a60c72ba00e1" />
