### PR TITLE
[FIX] Hero Section of recipe Not Responsive on Mobile – Misaligned & Cut Off 

### DIFF
--- a/app/recipe/page.jsx
+++ b/app/recipe/page.jsx
@@ -92,13 +92,13 @@ export default function ViewRecipePage() {
         />
 
         <div
-          className={`min-h-screen py-10 px-4 mt-20 bg-base-100 flex gap-2 justify-center items-start transition-all duration-300 ${
+          className={`min-h-screen py-10 px-4 mt-10 md:mt-20 bg-base-100 flex flex-col md:flex-row gap-2 justify-center items-start transition-all duration-300 ${
             showResults ? "opacity-80 blur-sm" : "opacity-100"
           }`}
         >
           <BackButton />
 
-          <div className="relative mt-14 md:mt-0 max-w-4xl w-full bg-base-200 shadow-xl rounded-xl">
+          <div className="relative mt-5 md:mt-0 max-w-4xl w-full bg-base-200 shadow-xl rounded-xl">
             <div className="p-6 md:p-12">
               <header className="relative text-center mb-12">
                 <div className="inline-block">


### PR DESCRIPTION
## 📄 Description

This pull request enhances the responsiveness of the recipe view page. The hero section is now fully centered and properly scaled for mobile screens, fixing the layout cut-off issue, unnecessary space between them also have been removed.

## 🔗 Related Issue IMP*

Closes #527 

## 📸 Screenshots (if applicable)
--before
<img width="406" height="754" alt="image" src="https://github.com/user-attachments/assets/e6e5bf19-fbdd-4e81-bfaf-26ba242213c5" />



--after
<img width="406" height="839" alt="image" src="https://github.com/user-attachments/assets/135864b4-3781-453f-a43d-b9a984710e37" />


## ✅ Checklist

- [✅  ] My code compiles without errors
- [ ✅ ] I have tested my changes
- [✅  ] I have updated documentation if necessary
