### PR TITLE
removed the logo section and logo link in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@
 
 <img src="https://user-images.githubusercontent.com/74038190/212284100-561aa473-3905-4a80-b561-0d28506553ee.gif" width="150%">
 
-![GSSoC Logo](https://github.com/Ayushjhawar8/Flavor-ai/blob/main/screenshots/gssoc%20logo.png)
 
 ## 🌟 Exciting News...
 


### PR DESCRIPTION
removed the Gssoc section from the readme.md 

<img width="2940" height="588" alt="image" src="https://github.com/user-attachments/assets/23c2ccbc-650d-49bf-8e4f-930088213417" />
